### PR TITLE
Add forgotten % in eprint:arxiv field format

### DIFF
--- a/phys.bbx
+++ b/phys.bbx
@@ -62,8 +62,8 @@
         arXiv\addcolon
         \nolinkurl{#1}%
         \iffieldundef{eprintclass}
-	 {}
-	 {\addspace\UrlFont{\mkbibbrackets{\thefield{eprintclass}}}}}}
+          {}
+          {\addspace\UrlFont{\mkbibbrackets{\thefield{eprintclass}}}}}}
     {arXiv\addcolon
       \nolinkurl{#1}
       \iffieldundef{eprintclass}
@@ -426,9 +426,9 @@
             {%
               \setunit{\addcomma\space}%
               \usebibmacro{authorstrg}%
-	        }%
-	    }%
-	}
+            }%
+        }%
+    }
     {}%
 }
 

--- a/phys.bbx
+++ b/phys.bbx
@@ -65,7 +65,7 @@
           {}
           {\addspace\UrlFont{\mkbibbrackets{\thefield{eprintclass}}}}}}
     {arXiv\addcolon
-      \nolinkurl{#1}
+      \nolinkurl{#1}%
       \iffieldundef{eprintclass}
         {}
         {\addspace\UrlFont{\mkbibbrackets{\thefield{eprintclass}}}}}}


### PR DESCRIPTION
Cf. https://github.com/plk/biblatex/commit/36a0833bc010d29c68f36d26acb4cc4ac0da1cc8

I could not resist to replace some tabs with spaces for nicer indentation.