### PR TITLE
Fix support for collaboration field

### DIFF
--- a/biblatex-phys.bib
+++ b/biblatex-phys.bib
@@ -54,6 +54,28 @@
   edition     = {5},
 }
 
+@Article{Arneodo2008,
+  title         = {Universal Intermittent Properties of Particle Trajectories in
+                   Highly Turbulent Flows},
+  author        = {Arnèodo, A. and Benzi, R. and Berg, J. and Biferale, L. and
+                   Bodenschatz, E. and Busse, A. and Calzavarini, E. and
+                   Castaing, B.  and Cencini, M. and Chevillard, L. and Fisher,
+                   R. T. and Grauer, R.  and Homann, H. and Lamb, D. and
+                   Lanotte, A. S. and Lévèque, E. and Lüthi, B. and Mann, J. and
+                   Mordant, N. and Müller, W.-C. and Ott, S.  and Ouellette, N.
+                   T. and Pinton, J.-F. and Pope, S. B. and Roux, S.  G. and
+                   Toschi, F. and Xu, H. and Yeung, P. K.},
+  collaboration = {International Collaboration for Turbulence Research},
+  journal       = {Phys. Rev. Lett.},
+  volume        = {100},
+  issue         = {25},
+  pages         = {254504},
+  year          = {2008},
+  month         = {Jun},
+  publisher     = {American Physical Society},
+  doi           = {10.1103/PhysRevLett.100.254504},
+}
+
 @Book{Augustine1995,
   hyphenation = {american},
   author	     = {Augustine, Robert L.},

--- a/build.lua
+++ b/build.lua
@@ -18,7 +18,7 @@ typesetsuppfiles = {"*.bib"}
 unpackfiles = { }
 
 -- Install biblatex style files and use these as the sources
-installfiles = {"*.cbx", "*.bbx"}
+installfiles = {"*.cbx", "*.bbx", "*.dbx"}
 sourcefiles  = installfiles
 
 -- Release a TDS-style zip
@@ -27,7 +27,7 @@ packtdszip  = true
 -- No tests for this bundle
 testfildir = ""
 
-tagfiles = {"*.bbx", "*.cbx", "*.tex"}
+tagfiles = {"*.bbx", "*.cbx", "*.dbx", "*.tex"}
 
 function update_tag(file,content,tagname,tagdate)
   local pattern = "%d%d%d%d/%d%d/%d%d"

--- a/phys.bbx
+++ b/phys.bbx
@@ -434,7 +434,7 @@
         }%
       \iffieldundef{collaboration}
         {}
-        {\printfield[parens]{collaboration}}}
+        { \printfield[parens]{collaboration}}}
     {}%
 }
 

--- a/phys.dbx
+++ b/phys.dbx
@@ -1,0 +1,3 @@
+% Extend biblatex default data model (defined in blx-dm.def) with
+% "collaboration" field.
+\DeclareDatamodelFields[type=field, datatype=literal]{collaboration}


### PR DESCRIPTION
Previously, the collaboration field was not printed when present in a bib file (see also #11). This issue is fixed by extending the default biblatex data model to include the collaboration field.