### PR TITLE
allow setting articletitle and chaptertitle per-entry

### DIFF
--- a/phys.bbx
+++ b/phys.bbx
@@ -20,7 +20,13 @@
 \DeclareBibliographyOption{articletitle}[true]{%
   \settoggle{bbx:articletitle}{#1}%
 }
+\DeclareEntryOption{articletitle}[true]{%
+  \settoggle{bbx:articletitle}{#1}%
+}
 \DeclareBibliographyOption{chaptertitle}[true]{%
+  \settoggle{bbx:chaptertitle}{#1}%
+}
+\DeclareEntryOption{chaptertitle}[true]{%
   \settoggle{bbx:chaptertitle}{#1}%
 }
 \DeclareBibliographyOption{pageranges}[true]{%


### PR DESCRIPTION
`articletitle` and `chaptertitle` are not recognised when provided in an `OPTIONS={...}` field of an entry. This is because they are declared as BibliographyOptions only. Declaring them also as EntryOptions fixes the problem.

To test you can e.g. apply this diff
```
diff --git a/biblatex-phys.bib b/biblatex-phys.bib
index 6f0f9b5..2fe28c4 100644
--- a/biblatex-phys.bib
+++ b/biblatex-phys.bib
@@ -31,6 +31,7 @@
   pages       = {361-363},
   number      = {1},
   doi         = {10.1021/ja00001a054},
+  OPTIONS={articletitle=false}
 }
 
 @Patent{Arduengo2001,
@@ -223,6 +224,7 @@
   chapter     = {V.3.1.1},
   pages       = {2119--2140},
   location    = {New York},
+  OPTIONS={chaptertitle=false}
 }
 
 @Book{Heyn1986,```