### PR TITLE
Avoid printing doi twice

### DIFF
--- a/phys.bbx
+++ b/phys.bbx
@@ -466,17 +466,13 @@
     {%
       \iffieldundef{eid}
         {%
-          \printfield{doi}%
-          \clearfield{doi}%
-        }%
-        {\@firstofone}%
-    }%
-    {\@firstofone}%
-    {%
-      \iftoggle{bbx:doi}
-        {}
-        {\clearfield{doi}}%
-    }%
+          \iftoggle{bbx:doi}
+            {}
+            {\printfield{doi}}%
+        }
+        {}%
+    }
+    {}%
 }
 
 \newbibmacro*{related:translatedas}[1]{%


### PR DESCRIPTION
Fixes #33.

As far as I can tell, the issue stems from the fact the the `\clearfield{doi}` are trapped in the hyperlink group (for articles). I just disabled printing the doi instead of the pages when it is to be printed in any case. I also removed the `\clearfields` as they are unreliable and should be unnecessary now.

I thought about preventing the second occurence of the doi instead but this was both inconsistent (doi in different places depending on the presence of `pages`) and less clean (checking if `pages` and `eid` are both missing is not quite the same as checking that the doi has already been typeset), so I chose to suppress the first occurence.