### PR TITLE
fix: inverted conditional for doi

### DIFF
--- a/phys.bbx
+++ b/phys.bbx
@@ -467,8 +467,8 @@
       \iffieldundef{eid}
         {%
           \iftoggle{bbx:doi}
-            {}
-            {\printfield{doi}}%
+            {\printfield{doi}}
+            {}%
         }
         {}%
     }


### PR DESCRIPTION
If `doi=false` the DOI should *not* be printed, I guess.